### PR TITLE
build: Update jupyter-book notebook execute to be off for now

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,10 +29,10 @@ parse:
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
 execute:
-  execute_notebooks: "cache"
-  allow_errors: false
+  execute_notebooks: "off"
+  # allow_errors: false
   # Per-cell notebook execution limit (seconds)
-  timeout: 300
+  # timeout: 300
 
 # Define the name of the latex output file for PDF builds
 latex:


### PR DESCRIPTION
This turns off the execution of notebook during build time.. probably will need to turn back on in the future. So this means that notebook should already be executed.